### PR TITLE
feat: changes demo for GitHub Pages

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -6,6 +6,10 @@ set -e
 # build
 npm run build
 
+# target build.js is in different path on development and production of GitHub Pages
+# A better way should be using [html-webpack-plugin](https://github.com/jantimon/html-webpack-plugin)
+cp index.pages.html dist/index.html
+
 # navigate into the build output directory
 cd dist
 
@@ -20,6 +24,6 @@ git commit -m 'deploy'
 # git push -f git@github.com:<USERNAME>/<USERNAME>.github.io.git master
 
 # if you are deploying to https://<USERNAME>.github.io/<REPO>
-git push -f git@github.com:<USERNAME>/<REPO>.git master:gh-pages
+git push -f git@github.com:jedrekdomanski/bikeramp-front.git master:gh-pages
 
 cd -

--- a/index.pages.html
+++ b/index.pages.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>vue-update</title>
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
+  </head>
+  <body>
+    <div id="app"></div>
+    <script src="/bikeramp-front/build.js"></script>
+    <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js" integrity="sha384-ZMP7rVo3mIykV+2+9J3UJ46jBk0WLaUAdn689aCwoqbBJiSnjAK/l8WvCWPIPm49" crossorigin="anonymous"></script>
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js" integrity="sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy" crossorigin="anonymous"></script>
+  </body>
+</html>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,7 +5,7 @@ module.exports = {
   entry: './src/main.js',
   output: {
     path: path.resolve(__dirname, './dist'),
-    publicPath: '/dist/',
+    publicPath: '/bikeramp-front/',
     filename: 'build.js'
   },
   module: {


### PR DESCRIPTION
Here is a tiny demo to help you to deploy your frontend App to GitHub Pages.

You are not using `vue-cli` at all so `vue.config.js` will not work.

The original `index.html` is not included in `gh-pgaes` branch and is always requesting `/dist/build.js` which is always incorrect path.


All you need to do then is running `npm run build && bash deploy.sh`.